### PR TITLE
Write sdk flags directly during replay

### DIFF
--- a/internal/internal_flags.go
+++ b/internal/internal_flags.go
@@ -94,6 +94,16 @@ func (sf *sdkFlags) tryUse(flag sdkFlag, record bool) bool {
 	}
 }
 
+// set marks a flag as in current use regardless of replay status.
+func (sf *sdkFlags) set(flags ...sdkFlag) {
+	if !sf.capabilities.GetSdkMetadata() {
+		return
+	}
+	for _, flag := range flags {
+		sf.currentFlags[flag] = true
+	}
+}
+
 // markSDKFlagsSent marks all sdk flags as sent to the server.
 func (sf *sdkFlags) markSDKFlagsSent() {
 	for flag := range sf.newFlags {

--- a/internal/internal_flags_test.go
+++ b/internal/internal_flags_test.go
@@ -1,0 +1,39 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+)
+
+var (
+	metadataDisabled = workflowservice.GetSystemInfoResponse_Capabilities{}
+	metadataEnabled  = workflowservice.GetSystemInfoResponse_Capabilities{
+		SdkMetadata: true,
+	}
+)
+
+const testFlag = SDKFlagChildWorkflowErrorExecution
+
+func TestSet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no server sdk metadata support", func(t *testing.T) {
+		flags := newSDKFlags(&metadataDisabled)
+		flags.set(testFlag)
+		require.Empty(t, flags.gatherNewSDKFlags(),
+			"flags assigned when servier does not support metadata are dropped")
+		require.False(t, flags.tryUse(testFlag, false),
+			"flags assigned when servier does not support metadata are dropped")
+	})
+
+	t.Run("with server sdk metadata support", func(t *testing.T) {
+		flags := newSDKFlags(&metadataEnabled)
+		flags.set(testFlag)
+		require.Empty(t, flags.gatherNewSDKFlags(),
+			"flag set via sdkFlags.set is not 'new'")
+		require.True(t, flags.tryUse(testFlag, false),
+			"flag set via sdkFlags.set should be immediately visible")
+	})
+}

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -169,6 +169,7 @@ type (
 		nextEventID    int64 // next expected eventID for sanity
 		lastEventID    int64 // last expected eventID, zero indicates read until end of stream
 		next           []*historypb.HistoryEvent
+		nextFlags      []sdkFlag
 		binaryChecksum string
 	}
 
@@ -288,7 +289,7 @@ func isCommandEvent(eventType enumspb.EventType) bool {
 // TODO(maxim): Refactor to return a struct instead of multiple parameters
 func (eh *history) NextCommandEvents() (result []*historypb.HistoryEvent, markers []*historypb.HistoryEvent, binaryChecksum string, sdkFlags []sdkFlag, err error) {
 	if eh.next == nil {
-		eh.next, _, sdkFlags, err = eh.nextCommandEvents()
+		eh.next, _, eh.nextFlags, err = eh.nextCommandEvents()
 		if err != nil {
 			return result, markers, eh.binaryChecksum, sdkFlags, err
 		}
@@ -296,8 +297,9 @@ func (eh *history) NextCommandEvents() (result []*historypb.HistoryEvent, marker
 
 	result = eh.next
 	checksum := eh.binaryChecksum
+	sdkFlags = eh.nextFlags
 	if len(result) > 0 {
-		eh.next, markers, sdkFlags, err = eh.nextCommandEvents()
+		eh.next, markers, eh.nextFlags, err = eh.nextCommandEvents()
 	}
 	return result, markers, checksum, sdkFlags, err
 }

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -890,7 +890,6 @@ func (w *workflowExecutionContextImpl) ProcessWorkflowTask(workflowTask *workflo
 	eventHandler.ResetLAWFTAttemptCounts()
 	eventHandler.sdkFlags.markSDKFlagsSent()
 
-	// Process events
 ProcessEvents:
 	for {
 		reorderedEvents, markers, binaryChecksum, flags, err := reorderedHistory.NextCommandEvents()
@@ -898,6 +897,7 @@ ProcessEvents:
 			return nil, err
 		}
 
+		eventHandler.sdkFlags.set(flags...)
 		if len(reorderedEvents) == 0 {
 			break ProcessEvents
 		}

--- a/test/replaytests/replay_test.go
+++ b/test/replaytests/replay_test.go
@@ -291,6 +291,14 @@ func (s *replayTestSuite) TestVersionLoopWorkflow() {
 	require.NoError(s.T(), err)
 }
 
+func (s *replayTestSuite) TestVersionLoopWorkflowTaskWorkflow() {
+	replayer := worker.NewWorkflowReplayer()
+	replayer.RegisterWorkflow(VersionLoopWorkflowMultipleTasks)
+	// Verify we can replay a workflow with SDK flags and multiple workflow tasks
+	err := replayer.ReplayWorkflowHistoryFromJSONFile(ilog.NewDefaultLogger(), "workflow_loop_task.json")
+	require.NoError(s.T(), err)
+}
+
 func (s *replayTestSuite) TestUnkownSDKFlag() {
 	replayer := worker.NewWorkflowReplayer()
 	replayer.RegisterWorkflow(VersionLoopWorkflow)

--- a/test/replaytests/workflow_loop_task.json
+++ b/test/replaytests/workflow_loop_task.json
@@ -1,0 +1,7339 @@
+{
+ "events": [
+  {
+   "eventId": "1",
+   "eventTime": "2023-05-19T20:43:14.842850966Z",
+   "eventType": "WorkflowExecutionStarted",
+   "taskId": "4198056",
+   "workflowExecutionStartedEventAttributes": {
+    "workflowType": {
+     "name": "VersionLoopWorkflowMultipleTasks"
+    },
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "input": {
+     "payloads": [
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkIg=="
+      },
+      {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg=="
+       },
+       "data": "NjQ="
+      }
+     ]
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "workflowTaskTimeout": "10s",
+    "originalExecutionRunId": "46588328-5dbd-4fea-a0ae-f785c2a4479d",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "firstExecutionRunId": "46588328-5dbd-4fea-a0ae-f785c2a4479d",
+    "attempt": 1,
+    "firstWorkflowTaskBackoff": "0s",
+    "header": {
+
+    }
+   }
+  },
+  {
+   "eventId": "2",
+   "eventTime": "2023-05-19T20:43:14.842873466Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198057",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "replay-test",
+     "kind": "Normal"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "3",
+   "eventTime": "2023-05-19T20:43:14.856730091Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198064",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "2",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "d15aadda-c8ca-408d-b5e8-205d99f92bbb",
+    "historySizeBytes": "746"
+   }
+  },
+  {
+   "eventId": "4",
+   "eventTime": "2023-05-19T20:43:14.866301341Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198068",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "2",
+    "startedEventId": "3",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+     "langUsedFlags": [
+      1
+     ]
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "5",
+   "eventTime": "2023-05-19T20:43:14.866321091Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198069",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "6",
+   "eventTime": "2023-05-19T20:43:14.867105758Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198070",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "4",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "7",
+   "eventTime": "2023-05-19T20:43:14.867110800Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198071",
+   "timerStartedEventAttributes": {
+    "timerId": "7",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "4"
+   }
+  },
+  {
+   "eventId": "8",
+   "eventTime": "2023-05-19T20:43:14.873663883Z",
+   "eventType": "TimerFired",
+   "taskId": "4198076",
+   "timerFiredEventAttributes": {
+    "timerId": "7",
+    "startedEventId": "7"
+   }
+  },
+  {
+   "eventId": "9",
+   "eventTime": "2023-05-19T20:43:14.873668550Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198077",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "10",
+   "eventTime": "2023-05-19T20:43:14.879156883Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198081",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "9",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "2b78e0fa-6521-42d2-8c73-3ef764045534",
+    "historySizeBytes": "1462"
+   }
+  },
+  {
+   "eventId": "11",
+   "eventTime": "2023-05-19T20:43:14.886060716Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198085",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "9",
+    "startedEventId": "10",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "12",
+   "eventTime": "2023-05-19T20:43:14.886070175Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198086",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "11"
+   }
+  },
+  {
+   "eventId": "13",
+   "eventTime": "2023-05-19T20:43:14.886681633Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198087",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "11",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "14",
+   "eventTime": "2023-05-19T20:43:14.886687425Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198088",
+   "timerStartedEventAttributes": {
+    "timerId": "14",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "11"
+   }
+  },
+  {
+   "eventId": "15",
+   "eventTime": "2023-05-19T20:43:15.880828383Z",
+   "eventType": "TimerFired",
+   "taskId": "4198092",
+   "timerFiredEventAttributes": {
+    "timerId": "14",
+    "startedEventId": "14"
+   }
+  },
+  {
+   "eventId": "16",
+   "eventTime": "2023-05-19T20:43:15.880856758Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198093",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "17",
+   "eventTime": "2023-05-19T20:43:15.897770675Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198097",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "16",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "ff0f816a-e831-4e42-9a11-0059b30e7883",
+    "historySizeBytes": "2232"
+   }
+  },
+  {
+   "eventId": "18",
+   "eventTime": "2023-05-19T20:43:15.914744133Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198101",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "16",
+    "startedEventId": "17",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "19",
+   "eventTime": "2023-05-19T20:43:15.914766050Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198102",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "18"
+   }
+  },
+  {
+   "eventId": "20",
+   "eventTime": "2023-05-19T20:43:15.915556800Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198103",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "18",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "21",
+   "eventTime": "2023-05-19T20:43:15.915567800Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198104",
+   "timerStartedEventAttributes": {
+    "timerId": "21",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "18"
+   }
+  },
+  {
+   "eventId": "22",
+   "eventTime": "2023-05-19T20:43:16.878276842Z",
+   "eventType": "TimerFired",
+   "taskId": "4198108",
+   "timerFiredEventAttributes": {
+    "timerId": "21",
+    "startedEventId": "21"
+   }
+  },
+  {
+   "eventId": "23",
+   "eventTime": "2023-05-19T20:43:16.878284134Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198109",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "24",
+   "eventTime": "2023-05-19T20:43:16.888451717Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198113",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "23",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "dba57764-8c82-4e53-bbc6-6d254588d02d",
+    "historySizeBytes": "3054"
+   }
+  },
+  {
+   "eventId": "25",
+   "eventTime": "2023-05-19T20:43:16.897466259Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198117",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "23",
+    "startedEventId": "24",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "26",
+   "eventTime": "2023-05-19T20:43:16.897475884Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198118",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "25"
+   }
+  },
+  {
+   "eventId": "27",
+   "eventTime": "2023-05-19T20:43:16.898102759Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198119",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "25",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "28",
+   "eventTime": "2023-05-19T20:43:16.898108259Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198120",
+   "timerStartedEventAttributes": {
+    "timerId": "28",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "25"
+   }
+  },
+  {
+   "eventId": "29",
+   "eventTime": "2023-05-19T20:43:17.879112134Z",
+   "eventType": "TimerFired",
+   "taskId": "4198124",
+   "timerFiredEventAttributes": {
+    "timerId": "28",
+    "startedEventId": "28"
+   }
+  },
+  {
+   "eventId": "30",
+   "eventTime": "2023-05-19T20:43:17.879119676Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198125",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "31",
+   "eventTime": "2023-05-19T20:43:17.891370259Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198129",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "30",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "f8ac8b2e-a18e-47c3-9ea7-1e28346c8f77",
+    "historySizeBytes": "3927"
+   }
+  },
+  {
+   "eventId": "32",
+   "eventTime": "2023-05-19T20:43:17.906059093Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198133",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "30",
+    "startedEventId": "31",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "33",
+   "eventTime": "2023-05-19T20:43:17.906077801Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198134",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "32"
+   }
+  },
+  {
+   "eventId": "34",
+   "eventTime": "2023-05-19T20:43:17.907575551Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198135",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "32",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "35",
+   "eventTime": "2023-05-19T20:43:17.907593593Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198136",
+   "timerStartedEventAttributes": {
+    "timerId": "35",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "32"
+   }
+  },
+  {
+   "eventId": "36",
+   "eventTime": "2023-05-19T20:43:18.883739260Z",
+   "eventType": "TimerFired",
+   "taskId": "4198140",
+   "timerFiredEventAttributes": {
+    "timerId": "35",
+    "startedEventId": "35"
+   }
+  },
+  {
+   "eventId": "37",
+   "eventTime": "2023-05-19T20:43:18.883753427Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198141",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "38",
+   "eventTime": "2023-05-19T20:43:18.894563385Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198145",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "37",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c6c625e5-2d87-4236-86da-9cf847eefbd7",
+    "historySizeBytes": "4851"
+   }
+  },
+  {
+   "eventId": "39",
+   "eventTime": "2023-05-19T20:43:18.910349343Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198149",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "37",
+    "startedEventId": "38",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "40",
+   "eventTime": "2023-05-19T20:43:18.910372302Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198150",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "39"
+   }
+  },
+  {
+   "eventId": "41",
+   "eventTime": "2023-05-19T20:43:18.911164260Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198151",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "39",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "42",
+   "eventTime": "2023-05-19T20:43:18.911176218Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198152",
+   "timerStartedEventAttributes": {
+    "timerId": "42",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "39"
+   }
+  },
+  {
+   "eventId": "43",
+   "eventTime": "2023-05-19T20:43:19.885111385Z",
+   "eventType": "TimerFired",
+   "taskId": "4198156",
+   "timerFiredEventAttributes": {
+    "timerId": "42",
+    "startedEventId": "42"
+   }
+  },
+  {
+   "eventId": "44",
+   "eventTime": "2023-05-19T20:43:19.885126010Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198157",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "45",
+   "eventTime": "2023-05-19T20:43:19.897135510Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198161",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "44",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c3f24d2e-2624-46b7-906a-907cb6a615ce",
+    "historySizeBytes": "5826"
+   }
+  },
+  {
+   "eventId": "46",
+   "eventTime": "2023-05-19T20:43:19.909221969Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198165",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "44",
+    "startedEventId": "45",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "47",
+   "eventTime": "2023-05-19T20:43:19.909242260Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198166",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "46"
+   }
+  },
+  {
+   "eventId": "48",
+   "eventTime": "2023-05-19T20:43:19.910076260Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198167",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "46",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "49",
+   "eventTime": "2023-05-19T20:43:19.910091177Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198168",
+   "timerStartedEventAttributes": {
+    "timerId": "49",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "46"
+   }
+  },
+  {
+   "eventId": "50",
+   "eventTime": "2023-05-19T20:43:20.887096219Z",
+   "eventType": "TimerFired",
+   "taskId": "4198172",
+   "timerFiredEventAttributes": {
+    "timerId": "49",
+    "startedEventId": "49"
+   }
+  },
+  {
+   "eventId": "51",
+   "eventTime": "2023-05-19T20:43:20.887111011Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198173",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "52",
+   "eventTime": "2023-05-19T20:43:20.897900219Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198177",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "51",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "7163d607-a317-4950-a0ab-5c506d446b1c",
+    "historySizeBytes": "6852"
+   }
+  },
+  {
+   "eventId": "53",
+   "eventTime": "2023-05-19T20:43:20.910593761Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198181",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "51",
+    "startedEventId": "52",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "54",
+   "eventTime": "2023-05-19T20:43:20.910615219Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198182",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjci"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "53"
+   }
+  },
+  {
+   "eventId": "55",
+   "eventTime": "2023-05-19T20:43:20.911324386Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198183",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "53",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "56",
+   "eventTime": "2023-05-19T20:43:20.911334719Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198184",
+   "timerStartedEventAttributes": {
+    "timerId": "56",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "53"
+   }
+  },
+  {
+   "eventId": "57",
+   "eventTime": "2023-05-19T20:43:21.890810053Z",
+   "eventType": "TimerFired",
+   "taskId": "4198188",
+   "timerFiredEventAttributes": {
+    "timerId": "56",
+    "startedEventId": "56"
+   }
+  },
+  {
+   "eventId": "58",
+   "eventTime": "2023-05-19T20:43:21.890826928Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198189",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "59",
+   "eventTime": "2023-05-19T20:43:21.905067761Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198193",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "58",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "114f3dec-9fd8-42af-92bd-dd5f45c74a6a",
+    "historySizeBytes": "7929"
+   }
+  },
+  {
+   "eventId": "60",
+   "eventTime": "2023-05-19T20:43:21.920554845Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198197",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "58",
+    "startedEventId": "59",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "61",
+   "eventTime": "2023-05-19T20:43:21.920576761Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198198",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgi"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "60"
+   }
+  },
+  {
+   "eventId": "62",
+   "eventTime": "2023-05-19T20:43:21.921343511Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198199",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "60",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "63",
+   "eventTime": "2023-05-19T20:43:21.921353761Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198200",
+   "timerStartedEventAttributes": {
+    "timerId": "63",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "60"
+   }
+  },
+  {
+   "eventId": "64",
+   "eventTime": "2023-05-19T20:43:22.890591178Z",
+   "eventType": "TimerFired",
+   "taskId": "4198204",
+   "timerFiredEventAttributes": {
+    "timerId": "63",
+    "startedEventId": "63"
+   }
+  },
+  {
+   "eventId": "65",
+   "eventTime": "2023-05-19T20:43:22.890604595Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198205",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "66",
+   "eventTime": "2023-05-19T20:43:22.901697512Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198209",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "65",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "0b665fae-ff5d-4c40-8fba-bc00a42f4ec2",
+    "historySizeBytes": "9057"
+   }
+  },
+  {
+   "eventId": "67",
+   "eventTime": "2023-05-19T20:43:22.914536137Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198213",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "65",
+    "startedEventId": "66",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "68",
+   "eventTime": "2023-05-19T20:43:22.914557803Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198214",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjki"
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "67"
+   }
+  },
+  {
+   "eventId": "69",
+   "eventTime": "2023-05-19T20:43:22.915142012Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198215",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "67",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "70",
+   "eventTime": "2023-05-19T20:43:22.915156553Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198216",
+   "timerStartedEventAttributes": {
+    "timerId": "70",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "67"
+   }
+  },
+  {
+   "eventId": "71",
+   "eventTime": "2023-05-19T20:43:23.891865804Z",
+   "eventType": "TimerFired",
+   "taskId": "4198220",
+   "timerFiredEventAttributes": {
+    "timerId": "70",
+    "startedEventId": "70"
+   }
+  },
+  {
+   "eventId": "72",
+   "eventTime": "2023-05-19T20:43:23.891880429Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198221",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "73",
+   "eventTime": "2023-05-19T20:43:23.907357929Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198225",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "72",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c88d39fa-5a61-49ca-a1c5-01f04b07ce64",
+    "historySizeBytes": "10236"
+   }
+  },
+  {
+   "eventId": "74",
+   "eventTime": "2023-05-19T20:43:23.918466262Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198229",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "72",
+    "startedEventId": "73",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "75",
+   "eventTime": "2023-05-19T20:43:23.918482096Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198230",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEwIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "74"
+   }
+  },
+  {
+   "eventId": "76",
+   "eventTime": "2023-05-19T20:43:23.919008012Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198231",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "74",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "77",
+   "eventTime": "2023-05-19T20:43:23.919014387Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198232",
+   "timerStartedEventAttributes": {
+    "timerId": "77",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "74"
+   }
+  },
+  {
+   "eventId": "78",
+   "eventTime": "2023-05-19T20:43:24.895140721Z",
+   "eventType": "TimerFired",
+   "taskId": "4198236",
+   "timerFiredEventAttributes": {
+    "timerId": "77",
+    "startedEventId": "77"
+   }
+  },
+  {
+   "eventId": "79",
+   "eventTime": "2023-05-19T20:43:24.895165138Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198237",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "80",
+   "eventTime": "2023-05-19T20:43:24.924118054Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198241",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "79",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "28fad6d6-a356-43ee-bc01-416dcbd7b4d2",
+    "historySizeBytes": "11468"
+   }
+  },
+  {
+   "eventId": "81",
+   "eventTime": "2023-05-19T20:43:24.946550054Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198245",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "79",
+    "startedEventId": "80",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "82",
+   "eventTime": "2023-05-19T20:43:24.946562721Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198246",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "81"
+   }
+  },
+  {
+   "eventId": "83",
+   "eventTime": "2023-05-19T20:43:24.947303221Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198247",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "81",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "84",
+   "eventTime": "2023-05-19T20:43:24.947310429Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198248",
+   "timerStartedEventAttributes": {
+    "timerId": "84",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "81"
+   }
+  },
+  {
+   "eventId": "85",
+   "eventTime": "2023-05-19T20:43:25.897118347Z",
+   "eventType": "TimerFired",
+   "taskId": "4198252",
+   "timerFiredEventAttributes": {
+    "timerId": "84",
+    "startedEventId": "84"
+   }
+  },
+  {
+   "eventId": "86",
+   "eventTime": "2023-05-19T20:43:25.897145513Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198253",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "87",
+   "eventTime": "2023-05-19T20:43:25.915846055Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198257",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "86",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "0e90cccb-558e-4edb-8a31-eb46b810d46c",
+    "historySizeBytes": "12752"
+   }
+  },
+  {
+   "eventId": "88",
+   "eventTime": "2023-05-19T20:43:25.932729013Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198261",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "86",
+    "startedEventId": "87",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "89",
+   "eventTime": "2023-05-19T20:43:25.932750388Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198262",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "88"
+   }
+  },
+  {
+   "eventId": "90",
+   "eventTime": "2023-05-19T20:43:25.933513638Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198263",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "88",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "91",
+   "eventTime": "2023-05-19T20:43:25.933526972Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198264",
+   "timerStartedEventAttributes": {
+    "timerId": "91",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "88"
+   }
+  },
+  {
+   "eventId": "92",
+   "eventTime": "2023-05-19T20:43:26.893506514Z",
+   "eventType": "TimerFired",
+   "taskId": "4198268",
+   "timerFiredEventAttributes": {
+    "timerId": "91",
+    "startedEventId": "91"
+   }
+  },
+  {
+   "eventId": "93",
+   "eventTime": "2023-05-19T20:43:26.893519014Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198269",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "94",
+   "eventTime": "2023-05-19T20:43:26.903674430Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198273",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "93",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "91bf3cdb-c42a-41a7-b92e-68c373f18e86",
+    "historySizeBytes": "14088"
+   }
+  },
+  {
+   "eventId": "95",
+   "eventTime": "2023-05-19T20:43:26.918101139Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198277",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "93",
+    "startedEventId": "94",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "96",
+   "eventTime": "2023-05-19T20:43:26.918121722Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198278",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEzIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "95"
+   }
+  },
+  {
+   "eventId": "97",
+   "eventTime": "2023-05-19T20:43:26.918699847Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198279",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "95",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "98",
+   "eventTime": "2023-05-19T20:43:26.918709847Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198280",
+   "timerStartedEventAttributes": {
+    "timerId": "98",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "95"
+   }
+  },
+  {
+   "eventId": "99",
+   "eventTime": "2023-05-19T20:43:27.905362167Z",
+   "eventType": "TimerFired",
+   "taskId": "4198284",
+   "timerFiredEventAttributes": {
+    "timerId": "98",
+    "startedEventId": "98"
+   }
+  },
+  {
+   "eventId": "100",
+   "eventTime": "2023-05-19T20:43:27.905389125Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198285",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "101",
+   "eventTime": "2023-05-19T20:43:27.924894375Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198289",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "100",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "ac7adec1-fc32-4afd-905a-ee8e49934c13",
+    "historySizeBytes": "15476"
+   }
+  },
+  {
+   "eventId": "102",
+   "eventTime": "2023-05-19T20:43:27.938409083Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198293",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "100",
+    "startedEventId": "101",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "103",
+   "eventTime": "2023-05-19T20:43:27.938430292Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198294",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE0Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "102"
+   }
+  },
+  {
+   "eventId": "104",
+   "eventTime": "2023-05-19T20:43:27.940042208Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198295",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "102",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "105",
+   "eventTime": "2023-05-19T20:43:27.940053125Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198296",
+   "timerStartedEventAttributes": {
+    "timerId": "105",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "102"
+   }
+  },
+  {
+   "eventId": "106",
+   "eventTime": "2023-05-19T20:43:28.903520625Z",
+   "eventType": "TimerFired",
+   "taskId": "4198300",
+   "timerFiredEventAttributes": {
+    "timerId": "105",
+    "startedEventId": "105"
+   }
+  },
+  {
+   "eventId": "107",
+   "eventTime": "2023-05-19T20:43:28.903550167Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198301",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "108",
+   "eventTime": "2023-05-19T20:43:28.926128584Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198305",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "107",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "8f48bc7d-5655-4406-acde-7a3aa1f2633a",
+    "historySizeBytes": "16918"
+   }
+  },
+  {
+   "eventId": "109",
+   "eventTime": "2023-05-19T20:43:28.943436459Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198309",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "107",
+    "startedEventId": "108",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "110",
+   "eventTime": "2023-05-19T20:43:28.943460542Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198310",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "109"
+   }
+  },
+  {
+   "eventId": "111",
+   "eventTime": "2023-05-19T20:43:28.944526042Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198311",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "109",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "112",
+   "eventTime": "2023-05-19T20:43:28.944536750Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198312",
+   "timerStartedEventAttributes": {
+    "timerId": "112",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "109"
+   }
+  },
+  {
+   "eventId": "113",
+   "eventTime": "2023-05-19T20:43:29.901562084Z",
+   "eventType": "TimerFired",
+   "taskId": "4198316",
+   "timerFiredEventAttributes": {
+    "timerId": "112",
+    "startedEventId": "112"
+   }
+  },
+  {
+   "eventId": "114",
+   "eventTime": "2023-05-19T20:43:29.901569251Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198317",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "115",
+   "eventTime": "2023-05-19T20:43:29.911796043Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198321",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "114",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "7d38a818-77a6-4f49-8804-239b2882afbe",
+    "historySizeBytes": "18413"
+   }
+  },
+  {
+   "eventId": "116",
+   "eventTime": "2023-05-19T20:43:29.926306001Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198325",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "114",
+    "startedEventId": "115",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "117",
+   "eventTime": "2023-05-19T20:43:29.926408876Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198326",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "116"
+   }
+  },
+  {
+   "eventId": "118",
+   "eventTime": "2023-05-19T20:43:29.927191293Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198327",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "116",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNS0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "119",
+   "eventTime": "2023-05-19T20:43:29.927199584Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198328",
+   "timerStartedEventAttributes": {
+    "timerId": "119",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "116"
+   }
+  },
+  {
+   "eventId": "120",
+   "eventTime": "2023-05-19T20:43:30.911066710Z",
+   "eventType": "TimerFired",
+   "taskId": "4198332",
+   "timerFiredEventAttributes": {
+    "timerId": "119",
+    "startedEventId": "119"
+   }
+  },
+  {
+   "eventId": "121",
+   "eventTime": "2023-05-19T20:43:30.911094460Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198333",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "122",
+   "eventTime": "2023-05-19T20:43:30.927844918Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198337",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "121",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "4b428856-5c39-4f90-93c5-e5dd6d8a60e0",
+    "historySizeBytes": "19960"
+   }
+  },
+  {
+   "eventId": "123",
+   "eventTime": "2023-05-19T20:43:30.944927960Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198341",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "121",
+    "startedEventId": "122",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "124",
+   "eventTime": "2023-05-19T20:43:30.944950335Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198342",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "123"
+   }
+  },
+  {
+   "eventId": "125",
+   "eventTime": "2023-05-19T20:43:30.945813918Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198343",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "123",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjctMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "126",
+   "eventTime": "2023-05-19T20:43:30.945828460Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198344",
+   "timerStartedEventAttributes": {
+    "timerId": "126",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "123"
+   }
+  },
+  {
+   "eventId": "127",
+   "eventTime": "2023-05-19T20:43:31.905586835Z",
+   "eventType": "TimerFired",
+   "taskId": "4198348",
+   "timerFiredEventAttributes": {
+    "timerId": "126",
+    "startedEventId": "126"
+   }
+  },
+  {
+   "eventId": "128",
+   "eventTime": "2023-05-19T20:43:31.905613252Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198349",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "129",
+   "eventTime": "2023-05-19T20:43:31.933556252Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198353",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "128",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "616c003e-fe38-484d-8a0b-722c114deaf3",
+    "historySizeBytes": "21560"
+   }
+  },
+  {
+   "eventId": "130",
+   "eventTime": "2023-05-19T20:43:31.950009918Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198357",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "128",
+    "startedEventId": "129",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "131",
+   "eventTime": "2023-05-19T20:43:31.950031835Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198358",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE4Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "130"
+   }
+  },
+  {
+   "eventId": "132",
+   "eventTime": "2023-05-19T20:43:31.950891460Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198359",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "130",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "133",
+   "eventTime": "2023-05-19T20:43:31.950903335Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198360",
+   "timerStartedEventAttributes": {
+    "timerId": "133",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "130"
+   }
+  },
+  {
+   "eventId": "134",
+   "eventTime": "2023-05-19T20:43:32.912023252Z",
+   "eventType": "TimerFired",
+   "taskId": "4198364",
+   "timerFiredEventAttributes": {
+    "timerId": "133",
+    "startedEventId": "133"
+   }
+  },
+  {
+   "eventId": "135",
+   "eventTime": "2023-05-19T20:43:32.912045794Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198365",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "136",
+   "eventTime": "2023-05-19T20:43:32.933847127Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198369",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "135",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "35d79865-6755-4bad-99ad-76ef724644a6",
+    "historySizeBytes": "23225"
+   }
+  },
+  {
+   "eventId": "137",
+   "eventTime": "2023-05-19T20:43:32.953570502Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198373",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "135",
+    "startedEventId": "136",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "138",
+   "eventTime": "2023-05-19T20:43:32.953599169Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198374",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "137"
+   }
+  },
+  {
+   "eventId": "139",
+   "eventTime": "2023-05-19T20:43:32.954636669Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198375",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "137",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "140",
+   "eventTime": "2023-05-19T20:43:32.954675294Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198376",
+   "timerStartedEventAttributes": {
+    "timerId": "140",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "137"
+   }
+  },
+  {
+   "eventId": "141",
+   "eventTime": "2023-05-19T20:43:33.923934628Z",
+   "eventType": "TimerFired",
+   "taskId": "4198380",
+   "timerFiredEventAttributes": {
+    "timerId": "140",
+    "startedEventId": "140"
+   }
+  },
+  {
+   "eventId": "142",
+   "eventTime": "2023-05-19T20:43:33.923946669Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198381",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "143",
+   "eventTime": "2023-05-19T20:43:33.933942211Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198385",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "142",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "d9ece4af-20a0-46fc-b63b-9c9b3d6f28a6",
+    "historySizeBytes": "24942"
+   }
+  },
+  {
+   "eventId": "144",
+   "eventTime": "2023-05-19T20:43:33.953107419Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198389",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "142",
+    "startedEventId": "143",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "145",
+   "eventTime": "2023-05-19T20:43:33.953128336Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198390",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIwIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "144"
+   }
+  },
+  {
+   "eventId": "146",
+   "eventTime": "2023-05-19T20:43:33.953847503Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198391",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "144",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "147",
+   "eventTime": "2023-05-19T20:43:33.953858628Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198392",
+   "timerStartedEventAttributes": {
+    "timerId": "147",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "144"
+   }
+  },
+  {
+   "eventId": "148",
+   "eventTime": "2023-05-19T20:43:34.913536545Z",
+   "eventType": "TimerFired",
+   "taskId": "4198396",
+   "timerFiredEventAttributes": {
+    "timerId": "147",
+    "startedEventId": "147"
+   }
+  },
+  {
+   "eventId": "149",
+   "eventTime": "2023-05-19T20:43:34.913565170Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198397",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "150",
+   "eventTime": "2023-05-19T20:43:34.930492670Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198401",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "149",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "fe2aeedc-147a-4d9b-96a1-63c2851174ab",
+    "historySizeBytes": "26711"
+   }
+  },
+  {
+   "eventId": "151",
+   "eventTime": "2023-05-19T20:43:34.946933878Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198405",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "149",
+    "startedEventId": "150",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "152",
+   "eventTime": "2023-05-19T20:43:34.946957420Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198406",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIxIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "151"
+   }
+  },
+  {
+   "eventId": "153",
+   "eventTime": "2023-05-19T20:43:34.948464503Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198407",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "151",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "154",
+   "eventTime": "2023-05-19T20:43:34.948476253Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198408",
+   "timerStartedEventAttributes": {
+    "timerId": "154",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "151"
+   }
+  },
+  {
+   "eventId": "155",
+   "eventTime": "2023-05-19T20:43:35.917141587Z",
+   "eventType": "TimerFired",
+   "taskId": "4198412",
+   "timerFiredEventAttributes": {
+    "timerId": "154",
+    "startedEventId": "154"
+   }
+  },
+  {
+   "eventId": "156",
+   "eventTime": "2023-05-19T20:43:35.917168920Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198413",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "157",
+   "eventTime": "2023-05-19T20:43:35.934847879Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198417",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "156",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "70e9be05-1f1b-49e7-b6d5-ff5680bef0e9",
+    "historySizeBytes": "28532"
+   }
+  },
+  {
+   "eventId": "158",
+   "eventTime": "2023-05-19T20:43:35.955950670Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198421",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "156",
+    "startedEventId": "157",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "159",
+   "eventTime": "2023-05-19T20:43:35.955971920Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198422",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIyIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "158"
+   }
+  },
+  {
+   "eventId": "160",
+   "eventTime": "2023-05-19T20:43:35.956988379Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198423",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "158",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "161",
+   "eventTime": "2023-05-19T20:43:35.957002504Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198424",
+   "timerStartedEventAttributes": {
+    "timerId": "161",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "158"
+   }
+  },
+  {
+   "eventId": "162",
+   "eventTime": "2023-05-19T20:43:36.914179129Z",
+   "eventType": "TimerFired",
+   "taskId": "4198428",
+   "timerFiredEventAttributes": {
+    "timerId": "161",
+    "startedEventId": "161"
+   }
+  },
+  {
+   "eventId": "163",
+   "eventTime": "2023-05-19T20:43:36.914187588Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198429",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "164",
+   "eventTime": "2023-05-19T20:43:36.924822338Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198433",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "163",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c5b3428c-8474-44ea-8088-191a01122492",
+    "historySizeBytes": "30405"
+   }
+  },
+  {
+   "eventId": "165",
+   "eventTime": "2023-05-19T20:43:36.936729546Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198437",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "163",
+    "startedEventId": "164",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "166",
+   "eventTime": "2023-05-19T20:43:36.936739921Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198438",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIzIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "165"
+   }
+  },
+  {
+   "eventId": "167",
+   "eventTime": "2023-05-19T20:43:36.937247004Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198439",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "165",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "168",
+   "eventTime": "2023-05-19T20:43:36.937253254Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198440",
+   "timerStartedEventAttributes": {
+    "timerId": "168",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "165"
+   }
+  },
+  {
+   "eventId": "169",
+   "eventTime": "2023-05-19T20:43:37.925088463Z",
+   "eventType": "TimerFired",
+   "taskId": "4198444",
+   "timerFiredEventAttributes": {
+    "timerId": "168",
+    "startedEventId": "168"
+   }
+  },
+  {
+   "eventId": "170",
+   "eventTime": "2023-05-19T20:43:37.925116380Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198445",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "171",
+   "eventTime": "2023-05-19T20:43:37.948928546Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198449",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "170",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "f731a34f-a7e6-4f12-a7d3-06ac1eda7f9c",
+    "historySizeBytes": "32330"
+   }
+  },
+  {
+   "eventId": "172",
+   "eventTime": "2023-05-19T20:43:37.967702255Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198453",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "170",
+    "startedEventId": "171",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "173",
+   "eventTime": "2023-05-19T20:43:37.967735546Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198454",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI0Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "172"
+   }
+  },
+  {
+   "eventId": "174",
+   "eventTime": "2023-05-19T20:43:37.968762171Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198455",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "172",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "175",
+   "eventTime": "2023-05-19T20:43:37.968773713Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198456",
+   "timerStartedEventAttributes": {
+    "timerId": "175",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "172"
+   }
+  },
+  {
+   "eventId": "176",
+   "eventTime": "2023-05-19T20:43:38.925987380Z",
+   "eventType": "TimerFired",
+   "taskId": "4198460",
+   "timerFiredEventAttributes": {
+    "timerId": "175",
+    "startedEventId": "175"
+   }
+  },
+  {
+   "eventId": "177",
+   "eventTime": "2023-05-19T20:43:38.926017838Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198461",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "178",
+   "eventTime": "2023-05-19T20:43:38.944214088Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198465",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "177",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c25cd253-b7fd-4341-9042-6540f361c43d",
+    "historySizeBytes": "34307"
+   }
+  },
+  {
+   "eventId": "179",
+   "eventTime": "2023-05-19T20:43:38.960902422Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198469",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "177",
+    "startedEventId": "178",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "180",
+   "eventTime": "2023-05-19T20:43:38.960926130Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198470",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI1Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "179"
+   }
+  },
+  {
+   "eventId": "181",
+   "eventTime": "2023-05-19T20:43:38.961483838Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198471",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "179",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNi0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "182",
+   "eventTime": "2023-05-19T20:43:38.961495297Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198472",
+   "timerStartedEventAttributes": {
+    "timerId": "182",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "179"
+   }
+  },
+  {
+   "eventId": "183",
+   "eventTime": "2023-05-19T20:43:39.928200172Z",
+   "eventType": "TimerFired",
+   "taskId": "4198476",
+   "timerFiredEventAttributes": {
+    "timerId": "182",
+    "startedEventId": "182"
+   }
+  },
+  {
+   "eventId": "184",
+   "eventTime": "2023-05-19T20:43:39.928231464Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198477",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "185",
+   "eventTime": "2023-05-19T20:43:39.947231839Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198481",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "184",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "fcf4c76e-bd6a-43a7-8b18-0983dafb2ca3",
+    "historySizeBytes": "36336"
+   }
+  },
+  {
+   "eventId": "186",
+   "eventTime": "2023-05-19T20:43:39.966320464Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198485",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "184",
+    "startedEventId": "185",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "187",
+   "eventTime": "2023-05-19T20:43:39.966376506Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198486",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI2Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "186"
+   }
+  },
+  {
+   "eventId": "188",
+   "eventTime": "2023-05-19T20:43:39.967280256Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198487",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "186",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "189",
+   "eventTime": "2023-05-19T20:43:39.967293547Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198488",
+   "timerStartedEventAttributes": {
+    "timerId": "189",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "186"
+   }
+  },
+  {
+   "eventId": "190",
+   "eventTime": "2023-05-19T20:43:40.929010089Z",
+   "eventType": "TimerFired",
+   "taskId": "4198492",
+   "timerFiredEventAttributes": {
+    "timerId": "189",
+    "startedEventId": "189"
+   }
+  },
+  {
+   "eventId": "191",
+   "eventTime": "2023-05-19T20:43:40.929032923Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198493",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "192",
+   "eventTime": "2023-05-19T20:43:40.948580048Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198497",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "191",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "ae7104eb-1dcb-4b85-b226-085e78444895",
+    "historySizeBytes": "38417"
+   }
+  },
+  {
+   "eventId": "193",
+   "eventTime": "2023-05-19T20:43:40.965907381Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198501",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "191",
+    "startedEventId": "192",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "194",
+   "eventTime": "2023-05-19T20:43:40.965928048Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198502",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI3Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "193"
+   }
+  },
+  {
+   "eventId": "195",
+   "eventTime": "2023-05-19T20:43:40.967163006Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198503",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "193",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "196",
+   "eventTime": "2023-05-19T20:43:40.967175131Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198504",
+   "timerStartedEventAttributes": {
+    "timerId": "196",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "193"
+   }
+  },
+  {
+   "eventId": "197",
+   "eventTime": "2023-05-19T20:43:41.928399840Z",
+   "eventType": "TimerFired",
+   "taskId": "4198508",
+   "timerFiredEventAttributes": {
+    "timerId": "196",
+    "startedEventId": "196"
+   }
+  },
+  {
+   "eventId": "198",
+   "eventTime": "2023-05-19T20:43:41.928432507Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198509",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "199",
+   "eventTime": "2023-05-19T20:43:41.947040798Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198513",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "198",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "ea26d31f-61de-4ad4-8765-9fea7a73eecf",
+    "historySizeBytes": "40550"
+   }
+  },
+  {
+   "eventId": "200",
+   "eventTime": "2023-05-19T20:43:41.966610673Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198517",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "198",
+    "startedEventId": "199",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "201",
+   "eventTime": "2023-05-19T20:43:41.966634257Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198518",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI4Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "200"
+   }
+  },
+  {
+   "eventId": "202",
+   "eventTime": "2023-05-19T20:43:41.967918340Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198519",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "200",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "203",
+   "eventTime": "2023-05-19T20:43:41.967934423Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198520",
+   "timerStartedEventAttributes": {
+    "timerId": "203",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "200"
+   }
+  },
+  {
+   "eventId": "204",
+   "eventTime": "2023-05-19T20:43:42.933432840Z",
+   "eventType": "TimerFired",
+   "taskId": "4198524",
+   "timerFiredEventAttributes": {
+    "timerId": "203",
+    "startedEventId": "203"
+   }
+  },
+  {
+   "eventId": "205",
+   "eventTime": "2023-05-19T20:43:42.933460340Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198525",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "206",
+   "eventTime": "2023-05-19T20:43:42.955880715Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198529",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "205",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "6c859db1-75e7-48a4-85dd-547c5f98f1a1",
+    "historySizeBytes": "42735"
+   }
+  },
+  {
+   "eventId": "207",
+   "eventTime": "2023-05-19T20:43:42.974432965Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198533",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "205",
+    "startedEventId": "206",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "208",
+   "eventTime": "2023-05-19T20:43:42.974459299Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198534",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI5Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "207"
+   }
+  },
+  {
+   "eventId": "209",
+   "eventTime": "2023-05-19T20:43:42.975913465Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198535",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "207",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTctMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "210",
+   "eventTime": "2023-05-19T20:43:42.975926507Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198536",
+   "timerStartedEventAttributes": {
+    "timerId": "210",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "207"
+   }
+  },
+  {
+   "eventId": "211",
+   "eventTime": "2023-05-19T20:43:43.943534424Z",
+   "eventType": "TimerFired",
+   "taskId": "4198540",
+   "timerFiredEventAttributes": {
+    "timerId": "210",
+    "startedEventId": "210"
+   }
+  },
+  {
+   "eventId": "212",
+   "eventTime": "2023-05-19T20:43:43.943546174Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198541",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "213",
+   "eventTime": "2023-05-19T20:43:43.954952383Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198545",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "212",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "52e49144-7a50-4ba8-8c6d-8fbbc02b6c0d",
+    "historySizeBytes": "44972"
+   }
+  },
+  {
+   "eventId": "214",
+   "eventTime": "2023-05-19T20:43:43.971239841Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198549",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "212",
+    "startedEventId": "213",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "215",
+   "eventTime": "2023-05-19T20:43:43.971264841Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198550",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMwIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "214"
+   }
+  },
+  {
+   "eventId": "216",
+   "eventTime": "2023-05-19T20:43:43.973782258Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198551",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "214",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI3LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "217",
+   "eventTime": "2023-05-19T20:43:43.973796508Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198552",
+   "timerStartedEventAttributes": {
+    "timerId": "217",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "214"
+   }
+  },
+  {
+   "eventId": "218",
+   "eventTime": "2023-05-19T20:43:44.935115925Z",
+   "eventType": "TimerFired",
+   "taskId": "4198556",
+   "timerFiredEventAttributes": {
+    "timerId": "217",
+    "startedEventId": "217"
+   }
+  },
+  {
+   "eventId": "219",
+   "eventTime": "2023-05-19T20:43:44.935144008Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198557",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "220",
+   "eventTime": "2023-05-19T20:43:44.959287050Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198561",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "219",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "e88850ce-7ae4-4653-aa97-3b54f341eefa",
+    "historySizeBytes": "47261"
+   }
+  },
+  {
+   "eventId": "221",
+   "eventTime": "2023-05-19T20:43:44.978479925Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198565",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "219",
+    "startedEventId": "220",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "222",
+   "eventTime": "2023-05-19T20:43:44.978504050Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198566",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMxIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "221"
+   }
+  },
+  {
+   "eventId": "223",
+   "eventTime": "2023-05-19T20:43:44.980300550Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198567",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "221",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "224",
+   "eventTime": "2023-05-19T20:43:44.980310966Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198568",
+   "timerStartedEventAttributes": {
+    "timerId": "224",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "221"
+   }
+  },
+  {
+   "eventId": "225",
+   "eventTime": "2023-05-19T20:43:45.939895883Z",
+   "eventType": "TimerFired",
+   "taskId": "4198572",
+   "timerFiredEventAttributes": {
+    "timerId": "224",
+    "startedEventId": "224"
+   }
+  },
+  {
+   "eventId": "226",
+   "eventTime": "2023-05-19T20:43:45.939922925Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198573",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "227",
+   "eventTime": "2023-05-19T20:43:45.956512550Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198577",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "226",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "081fe919-9235-46de-abf5-ff3b27b49db2",
+    "historySizeBytes": "49602"
+   }
+  },
+  {
+   "eventId": "228",
+   "eventTime": "2023-05-19T20:43:45.973242467Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198581",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "226",
+    "startedEventId": "227",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "229",
+   "eventTime": "2023-05-19T20:43:45.973265509Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198582",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMyIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "228"
+   }
+  },
+  {
+   "eventId": "230",
+   "eventTime": "2023-05-19T20:43:45.973859800Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198583",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "228",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "231",
+   "eventTime": "2023-05-19T20:43:45.973874050Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198584",
+   "timerStartedEventAttributes": {
+    "timerId": "231",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "228"
+   }
+  },
+  {
+   "eventId": "232",
+   "eventTime": "2023-05-19T20:43:46.936956301Z",
+   "eventType": "TimerFired",
+   "taskId": "4198588",
+   "timerFiredEventAttributes": {
+    "timerId": "231",
+    "startedEventId": "231"
+   }
+  },
+  {
+   "eventId": "233",
+   "eventTime": "2023-05-19T20:43:46.936978967Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198589",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "234",
+   "eventTime": "2023-05-19T20:43:46.951495842Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198593",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "233",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "6a349cbd-abaa-4663-b89f-fc34a1218eb3",
+    "historySizeBytes": "51995"
+   }
+  },
+  {
+   "eventId": "235",
+   "eventTime": "2023-05-19T20:43:46.970020801Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198597",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "233",
+    "startedEventId": "234",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "236",
+   "eventTime": "2023-05-19T20:43:46.970042426Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198598",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMzIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "235"
+   }
+  },
+  {
+   "eventId": "237",
+   "eventTime": "2023-05-19T20:43:46.970822384Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198599",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "235",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6OS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMxLTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "238",
+   "eventTime": "2023-05-19T20:43:46.970837551Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198600",
+   "timerStartedEventAttributes": {
+    "timerId": "238",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "235"
+   }
+  },
+  {
+   "eventId": "239",
+   "eventTime": "2023-05-19T20:43:47.942021218Z",
+   "eventType": "TimerFired",
+   "taskId": "4198604",
+   "timerFiredEventAttributes": {
+    "timerId": "238",
+    "startedEventId": "238"
+   }
+  },
+  {
+   "eventId": "240",
+   "eventTime": "2023-05-19T20:43:47.942049093Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198605",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "241",
+   "eventTime": "2023-05-19T20:43:47.961920051Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198609",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "240",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "596529fc-039a-4ce9-8b77-ebca5f7ac430",
+    "historySizeBytes": "54440"
+   }
+  },
+  {
+   "eventId": "242",
+   "eventTime": "2023-05-19T20:43:47.981259259Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198613",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "240",
+    "startedEventId": "241",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "243",
+   "eventTime": "2023-05-19T20:43:47.981285468Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198614",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM0Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "242"
+   }
+  },
+  {
+   "eventId": "244",
+   "eventTime": "2023-05-19T20:43:47.982043051Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198615",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "242",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE3LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNy0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "245",
+   "eventTime": "2023-05-19T20:43:47.982056468Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198616",
+   "timerStartedEventAttributes": {
+    "timerId": "245",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "242"
+   }
+  },
+  {
+   "eventId": "246",
+   "eventTime": "2023-05-19T20:43:48.943362260Z",
+   "eventType": "TimerFired",
+   "taskId": "4198620",
+   "timerFiredEventAttributes": {
+    "timerId": "245",
+    "startedEventId": "245"
+   }
+  },
+  {
+   "eventId": "247",
+   "eventTime": "2023-05-19T20:43:48.943392427Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198621",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "248",
+   "eventTime": "2023-05-19T20:43:48.965937885Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198625",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "247",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "9bbc943d-86d8-4b0a-8e93-0da71fcf360d",
+    "historySizeBytes": "56937"
+   }
+  },
+  {
+   "eventId": "249",
+   "eventTime": "2023-05-19T20:43:48.984377218Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198629",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "247",
+    "startedEventId": "248",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "250",
+   "eventTime": "2023-05-19T20:43:48.984400135Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198630",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM1Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "249"
+   }
+  },
+  {
+   "eventId": "251",
+   "eventTime": "2023-05-19T20:43:48.985565718Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198631",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "249",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDowLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzMtMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "252",
+   "eventTime": "2023-05-19T20:43:48.985578427Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198632",
+   "timerStartedEventAttributes": {
+    "timerId": "252",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "249"
+   }
+  },
+  {
+   "eventId": "253",
+   "eventTime": "2023-05-19T20:43:49.946432177Z",
+   "eventType": "TimerFired",
+   "taskId": "4198636",
+   "timerFiredEventAttributes": {
+    "timerId": "252",
+    "startedEventId": "252"
+   }
+  },
+  {
+   "eventId": "254",
+   "eventTime": "2023-05-19T20:43:49.946460427Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198637",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "255",
+   "eventTime": "2023-05-19T20:43:49.966861802Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198641",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "254",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "d729e06d-c89f-4131-b5a2-f972ada23645",
+    "historySizeBytes": "59486"
+   }
+  },
+  {
+   "eventId": "256",
+   "eventTime": "2023-05-19T20:43:49.986599427Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198645",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "254",
+    "startedEventId": "255",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "257",
+   "eventTime": "2023-05-19T20:43:49.986622510Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198646",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM2Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "256"
+   }
+  },
+  {
+   "eventId": "258",
+   "eventTime": "2023-05-19T20:43:49.987615594Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198647",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "256",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM1LTEiXQ=="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "259",
+   "eventTime": "2023-05-19T20:43:49.987628677Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198648",
+   "timerStartedEventAttributes": {
+    "timerId": "259",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "256"
+   }
+  },
+  {
+   "eventId": "260",
+   "eventTime": "2023-05-19T20:43:50.949566094Z",
+   "eventType": "TimerFired",
+   "taskId": "4198652",
+   "timerFiredEventAttributes": {
+    "timerId": "259",
+    "startedEventId": "259"
+   }
+  },
+  {
+   "eventId": "261",
+   "eventTime": "2023-05-19T20:43:50.949593928Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198653",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "262",
+   "eventTime": "2023-05-19T20:43:50.969827761Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198657",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "261",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "03d1cd7c-d649-42f0-a9f1-618da319f6fd",
+    "historySizeBytes": "62087"
+   }
+  },
+  {
+   "eventId": "263",
+   "eventTime": "2023-05-19T20:43:50.991514428Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198661",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "261",
+    "startedEventId": "262",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "264",
+   "eventTime": "2023-05-19T20:43:50.991541344Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198662",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM3Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "263"
+   }
+  },
+  {
+   "eventId": "265",
+   "eventTime": "2023-05-19T20:43:50.992584803Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198663",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "263",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6My0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ny0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjktMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjExLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE1LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Mi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6NS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMy0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6Ni0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTgtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMy0xIl0="
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "266",
+   "eventTime": "2023-05-19T20:43:50.992596428Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198664",
+   "timerStartedEventAttributes": {
+    "timerId": "266",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "263"
+   }
+  },
+  {
+   "eventId": "267",
+   "eventTime": "2023-05-19T20:43:51.954478053Z",
+   "eventType": "TimerFired",
+   "taskId": "4198668",
+   "timerFiredEventAttributes": {
+    "timerId": "266",
+    "startedEventId": "266"
+   }
+  },
+  {
+   "eventId": "268",
+   "eventTime": "2023-05-19T20:43:51.954506845Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198669",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "269",
+   "eventTime": "2023-05-19T20:43:51.973238928Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198673",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "268",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "0c8d3b02-f281-4910-badb-7fa7f7bccd6d",
+    "historySizeBytes": "64740"
+   }
+  },
+  {
+   "eventId": "270",
+   "eventTime": "2023-05-19T20:43:51.994000803Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198677",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "268",
+    "startedEventId": "269",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "271",
+   "eventTime": "2023-05-19T20:43:51.994022011Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198678",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM4Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "270"
+   }
+  },
+  {
+   "eventId": "272",
+   "eventTime": "2023-05-19T20:43:51.996049345Z",
+   "eventType": "UpsertWorkflowSearchAttributes",
+   "taskId": "4198679",
+   "upsertWorkflowSearchAttributesEventAttributes": {
+    "workflowTaskCompletedEventId": "270",
+    "searchAttributes": {
+     "indexedFields": {
+      "TemporalChangeVersion": {
+       "metadata": {
+        "encoding": "anNvbi9wbGFpbg==",
+        "type": "S2V5d29yZExpc3Q="
+       },
+       "data": "WyJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozOC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIzLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjAtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjE4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxOS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIyLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo4LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDo5LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM0LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNS0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTctMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjItMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIxLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDozMC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzYtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjEwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxNi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MjUtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjI2LTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoxMi0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MTMtMSIsInZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjIwLTEiLCJ2ZXJ5IHZlcnkgdmVyeSB2ZXJ5IGxvbmcgd29ya2Zsb3cgdmVyc2lvbiBpZDoyNC0xIiwidmVyeSB2ZXJ5IHZlcnkgdmVyeSBsb25nIHdvcmtmbG93IHZlcnNpb24gaWQ6MzUtMSJd"
+      }
+     }
+    }
+   }
+  },
+  {
+   "eventId": "273",
+   "eventTime": "2023-05-19T20:43:51.996058303Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198680",
+   "timerStartedEventAttributes": {
+    "timerId": "273",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "270"
+   }
+  },
+  {
+   "eventId": "274",
+   "eventTime": "2023-05-19T20:43:52.952387929Z",
+   "eventType": "TimerFired",
+   "taskId": "4198684",
+   "timerFiredEventAttributes": {
+    "timerId": "273",
+    "startedEventId": "273"
+   }
+  },
+  {
+   "eventId": "275",
+   "eventTime": "2023-05-19T20:43:52.952413512Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198685",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "276",
+   "eventTime": "2023-05-19T20:43:52.975891887Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198689",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "275",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "da557bce-311e-4bec-89c8-a51231fb9463",
+    "historySizeBytes": "67445"
+   }
+  },
+  {
+   "eventId": "277",
+   "eventTime": "2023-05-19T20:43:52.996088637Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198693",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "275",
+    "startedEventId": "276",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "278",
+   "eventTime": "2023-05-19T20:43:52.996111762Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198694",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjM5Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "277"
+   }
+  },
+  {
+   "eventId": "279",
+   "eventTime": "2023-05-19T20:43:52.996116804Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198695",
+   "timerStartedEventAttributes": {
+    "timerId": "279",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "277"
+   }
+  },
+  {
+   "eventId": "280",
+   "eventTime": "2023-05-19T20:43:53.953306096Z",
+   "eventType": "TimerFired",
+   "taskId": "4198698",
+   "timerFiredEventAttributes": {
+    "timerId": "279",
+    "startedEventId": "279"
+   }
+  },
+  {
+   "eventId": "281",
+   "eventTime": "2023-05-19T20:43:53.953334179Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198699",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "282",
+   "eventTime": "2023-05-19T20:43:53.971878554Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198703",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "281",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "29334e05-2690-44e2-9ad1-033af779c2c7",
+    "historySizeBytes": "68109"
+   }
+  },
+  {
+   "eventId": "283",
+   "eventTime": "2023-05-19T20:43:53.989806762Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198707",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "281",
+    "startedEventId": "282",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "284",
+   "eventTime": "2023-05-19T20:43:53.989830262Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198708",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQwIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "283"
+   }
+  },
+  {
+   "eventId": "285",
+   "eventTime": "2023-05-19T20:43:53.989834971Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198709",
+   "timerStartedEventAttributes": {
+    "timerId": "285",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "283"
+   }
+  },
+  {
+   "eventId": "286",
+   "eventTime": "2023-05-19T20:43:54.953993638Z",
+   "eventType": "TimerFired",
+   "taskId": "4198712",
+   "timerFiredEventAttributes": {
+    "timerId": "285",
+    "startedEventId": "285"
+   }
+  },
+  {
+   "eventId": "287",
+   "eventTime": "2023-05-19T20:43:54.954025346Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198713",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "288",
+   "eventTime": "2023-05-19T20:43:54.970921054Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198717",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "287",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "314f97c1-d623-435c-b7f1-7098992a065d",
+    "historySizeBytes": "68773"
+   }
+  },
+  {
+   "eventId": "289",
+   "eventTime": "2023-05-19T20:43:54.988465263Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198721",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "287",
+    "startedEventId": "288",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "290",
+   "eventTime": "2023-05-19T20:43:54.988488513Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198722",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQxIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "289"
+   }
+  },
+  {
+   "eventId": "291",
+   "eventTime": "2023-05-19T20:43:54.988492638Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198723",
+   "timerStartedEventAttributes": {
+    "timerId": "291",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "289"
+   }
+  },
+  {
+   "eventId": "292",
+   "eventTime": "2023-05-19T20:43:55.960588138Z",
+   "eventType": "TimerFired",
+   "taskId": "4198726",
+   "timerFiredEventAttributes": {
+    "timerId": "291",
+    "startedEventId": "291"
+   }
+  },
+  {
+   "eventId": "293",
+   "eventTime": "2023-05-19T20:43:55.960619513Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198727",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "294",
+   "eventTime": "2023-05-19T20:43:55.978844847Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198731",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "293",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "3e0f07e8-5784-4caa-8f02-f83480122a04",
+    "historySizeBytes": "69437"
+   }
+  },
+  {
+   "eventId": "295",
+   "eventTime": "2023-05-19T20:43:55.996895222Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198735",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "293",
+    "startedEventId": "294",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "296",
+   "eventTime": "2023-05-19T20:43:55.996920138Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198736",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQyIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "295"
+   }
+  },
+  {
+   "eventId": "297",
+   "eventTime": "2023-05-19T20:43:55.996924888Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198737",
+   "timerStartedEventAttributes": {
+    "timerId": "297",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "295"
+   }
+  },
+  {
+   "eventId": "298",
+   "eventTime": "2023-05-19T20:43:56.956824389Z",
+   "eventType": "TimerFired",
+   "taskId": "4198740",
+   "timerFiredEventAttributes": {
+    "timerId": "297",
+    "startedEventId": "297"
+   }
+  },
+  {
+   "eventId": "299",
+   "eventTime": "2023-05-19T20:43:56.956828889Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198741",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "300",
+   "eventTime": "2023-05-19T20:43:56.963389889Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198745",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "299",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "2388fad2-bb03-44f3-86ef-bb80b0f87937",
+    "historySizeBytes": "70101"
+   }
+  },
+  {
+   "eventId": "301",
+   "eventTime": "2023-05-19T20:43:56.972090347Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198749",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "299",
+    "startedEventId": "300",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "302",
+   "eventTime": "2023-05-19T20:43:56.972098305Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198750",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQzIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "301"
+   }
+  },
+  {
+   "eventId": "303",
+   "eventTime": "2023-05-19T20:43:56.972099930Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198751",
+   "timerStartedEventAttributes": {
+    "timerId": "303",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "301"
+   }
+  },
+  {
+   "eventId": "304",
+   "eventTime": "2023-05-19T20:43:57.961005167Z",
+   "eventType": "TimerFired",
+   "taskId": "4198754",
+   "timerFiredEventAttributes": {
+    "timerId": "303",
+    "startedEventId": "303"
+   }
+  },
+  {
+   "eventId": "305",
+   "eventTime": "2023-05-19T20:43:57.961034417Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198755",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "306",
+   "eventTime": "2023-05-19T20:43:57.984710792Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198759",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "305",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "93bf7b6d-1023-489f-9df9-af0a933313a1",
+    "historySizeBytes": "70765"
+   }
+  },
+  {
+   "eventId": "307",
+   "eventTime": "2023-05-19T20:43:58.001799583Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198763",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "305",
+    "startedEventId": "306",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "308",
+   "eventTime": "2023-05-19T20:43:58.001817667Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198764",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQ0Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "307"
+   }
+  },
+  {
+   "eventId": "309",
+   "eventTime": "2023-05-19T20:43:58.001821125Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198765",
+   "timerStartedEventAttributes": {
+    "timerId": "309",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "307"
+   }
+  },
+  {
+   "eventId": "310",
+   "eventTime": "2023-05-19T20:43:58.974010Z",
+   "eventType": "TimerFired",
+   "taskId": "4198768",
+   "timerFiredEventAttributes": {
+    "timerId": "309",
+    "startedEventId": "309"
+   }
+  },
+  {
+   "eventId": "311",
+   "eventTime": "2023-05-19T20:43:58.974024667Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198769",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "312",
+   "eventTime": "2023-05-19T20:43:58.986507042Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198773",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "311",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "d8e50644-4d32-4268-bd36-1f0c5028fa9e",
+    "historySizeBytes": "71423"
+   }
+  },
+  {
+   "eventId": "313",
+   "eventTime": "2023-05-19T20:43:59.000162792Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198777",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "311",
+    "startedEventId": "312",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "314",
+   "eventTime": "2023-05-19T20:43:59.000186542Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198778",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQ1Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "313"
+   }
+  },
+  {
+   "eventId": "315",
+   "eventTime": "2023-05-19T20:43:59.000190667Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198779",
+   "timerStartedEventAttributes": {
+    "timerId": "315",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "313"
+   }
+  },
+  {
+   "eventId": "316",
+   "eventTime": "2023-05-19T20:43:59.962553251Z",
+   "eventType": "TimerFired",
+   "taskId": "4198782",
+   "timerFiredEventAttributes": {
+    "timerId": "315",
+    "startedEventId": "315"
+   }
+  },
+  {
+   "eventId": "317",
+   "eventTime": "2023-05-19T20:43:59.962578209Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198783",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "318",
+   "eventTime": "2023-05-19T20:43:59.982563334Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198787",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "317",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "d458e9a0-7272-442a-8930-eb44d5c24d0b",
+    "historySizeBytes": "72081"
+   }
+  },
+  {
+   "eventId": "319",
+   "eventTime": "2023-05-19T20:43:59.997978334Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198791",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "317",
+    "startedEventId": "318",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "320",
+   "eventTime": "2023-05-19T20:43:59.997999584Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198792",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQ2Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "319"
+   }
+  },
+  {
+   "eventId": "321",
+   "eventTime": "2023-05-19T20:43:59.998003834Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198793",
+   "timerStartedEventAttributes": {
+    "timerId": "321",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "319"
+   }
+  },
+  {
+   "eventId": "322",
+   "eventTime": "2023-05-19T20:44:00.978751626Z",
+   "eventType": "TimerFired",
+   "taskId": "4198796",
+   "timerFiredEventAttributes": {
+    "timerId": "321",
+    "startedEventId": "321"
+   }
+  },
+  {
+   "eventId": "323",
+   "eventTime": "2023-05-19T20:44:00.978770418Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198797",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "324",
+   "eventTime": "2023-05-19T20:44:00.990588668Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198801",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "323",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "59b6039a-0ff6-45f2-85fc-cb83bcaafbcb",
+    "historySizeBytes": "72745"
+   }
+  },
+  {
+   "eventId": "325",
+   "eventTime": "2023-05-19T20:44:01.006095460Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198805",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "323",
+    "startedEventId": "324",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "326",
+   "eventTime": "2023-05-19T20:44:01.006120751Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198806",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQ3Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "325"
+   }
+  },
+  {
+   "eventId": "327",
+   "eventTime": "2023-05-19T20:44:01.006126751Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198807",
+   "timerStartedEventAttributes": {
+    "timerId": "327",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "325"
+   }
+  },
+  {
+   "eventId": "328",
+   "eventTime": "2023-05-19T20:44:01.965903043Z",
+   "eventType": "TimerFired",
+   "taskId": "4198810",
+   "timerFiredEventAttributes": {
+    "timerId": "327",
+    "startedEventId": "327"
+   }
+  },
+  {
+   "eventId": "329",
+   "eventTime": "2023-05-19T20:44:01.965928127Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198811",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "330",
+   "eventTime": "2023-05-19T20:44:01.986481294Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198815",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "329",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "2da8dae3-3334-4116-8650-5af8bd688ba3",
+    "historySizeBytes": "73406"
+   }
+  },
+  {
+   "eventId": "331",
+   "eventTime": "2023-05-19T20:44:02.001952544Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198819",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "329",
+    "startedEventId": "330",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "332",
+   "eventTime": "2023-05-19T20:44:02.002164085Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198820",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQ4Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "331"
+   }
+  },
+  {
+   "eventId": "333",
+   "eventTime": "2023-05-19T20:44:02.002169544Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198821",
+   "timerStartedEventAttributes": {
+    "timerId": "333",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "331"
+   }
+  },
+  {
+   "eventId": "334",
+   "eventTime": "2023-05-19T20:44:02.966849711Z",
+   "eventType": "TimerFired",
+   "taskId": "4198824",
+   "timerFiredEventAttributes": {
+    "timerId": "333",
+    "startedEventId": "333"
+   }
+  },
+  {
+   "eventId": "335",
+   "eventTime": "2023-05-19T20:44:02.966873711Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198825",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "336",
+   "eventTime": "2023-05-19T20:44:02.987621211Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198829",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "335",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "4e4068eb-88a0-42f7-8575-00c7fa636e0c",
+    "historySizeBytes": "74066"
+   }
+  },
+  {
+   "eventId": "337",
+   "eventTime": "2023-05-19T20:44:03.002055836Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198833",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "335",
+    "startedEventId": "336",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "338",
+   "eventTime": "2023-05-19T20:44:03.002078127Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198834",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjQ5Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "337"
+   }
+  },
+  {
+   "eventId": "339",
+   "eventTime": "2023-05-19T20:44:03.002082627Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198835",
+   "timerStartedEventAttributes": {
+    "timerId": "339",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "337"
+   }
+  },
+  {
+   "eventId": "340",
+   "eventTime": "2023-05-19T20:44:03.968479461Z",
+   "eventType": "TimerFired",
+   "taskId": "4198838",
+   "timerFiredEventAttributes": {
+    "timerId": "339",
+    "startedEventId": "339"
+   }
+  },
+  {
+   "eventId": "341",
+   "eventTime": "2023-05-19T20:44:03.968508836Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198839",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "342",
+   "eventTime": "2023-05-19T20:44:03.989663003Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198843",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "341",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c3c7fb6a-ddde-4617-83c2-f49a71b015d8",
+    "historySizeBytes": "74724"
+   }
+  },
+  {
+   "eventId": "343",
+   "eventTime": "2023-05-19T20:44:04.003902294Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198847",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "341",
+    "startedEventId": "342",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "344",
+   "eventTime": "2023-05-19T20:44:04.003923253Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198848",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUwIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "343"
+   }
+  },
+  {
+   "eventId": "345",
+   "eventTime": "2023-05-19T20:44:04.003927794Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198849",
+   "timerStartedEventAttributes": {
+    "timerId": "345",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "343"
+   }
+  },
+  {
+   "eventId": "346",
+   "eventTime": "2023-05-19T20:44:04.968258087Z",
+   "eventType": "TimerFired",
+   "taskId": "4198852",
+   "timerFiredEventAttributes": {
+    "timerId": "345",
+    "startedEventId": "345"
+   }
+  },
+  {
+   "eventId": "347",
+   "eventTime": "2023-05-19T20:44:04.968287170Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198853",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "348",
+   "eventTime": "2023-05-19T20:44:04.986023962Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198857",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "347",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "9ae6edf9-06c4-435c-83ec-3ae9d0e4cdc8",
+    "historySizeBytes": "75385"
+   }
+  },
+  {
+   "eventId": "349",
+   "eventTime": "2023-05-19T20:44:05.002887878Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198861",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "347",
+    "startedEventId": "348",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "350",
+   "eventTime": "2023-05-19T20:44:05.002915253Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198862",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUxIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "349"
+   }
+  },
+  {
+   "eventId": "351",
+   "eventTime": "2023-05-19T20:44:05.002920045Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198863",
+   "timerStartedEventAttributes": {
+    "timerId": "351",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "349"
+   }
+  },
+  {
+   "eventId": "352",
+   "eventTime": "2023-05-19T20:44:05.969050379Z",
+   "eventType": "TimerFired",
+   "taskId": "4198866",
+   "timerFiredEventAttributes": {
+    "timerId": "351",
+    "startedEventId": "351"
+   }
+  },
+  {
+   "eventId": "353",
+   "eventTime": "2023-05-19T20:44:05.969078379Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198867",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "354",
+   "eventTime": "2023-05-19T20:44:05.986450254Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198871",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "353",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "c37d7543-78ba-41ce-b5d8-137c63db52ba",
+    "historySizeBytes": "76046"
+   }
+  },
+  {
+   "eventId": "355",
+   "eventTime": "2023-05-19T20:44:06.002509754Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198875",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "353",
+    "startedEventId": "354",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "356",
+   "eventTime": "2023-05-19T20:44:06.002532795Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198876",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUyIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "355"
+   }
+  },
+  {
+   "eventId": "357",
+   "eventTime": "2023-05-19T20:44:06.002536837Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198877",
+   "timerStartedEventAttributes": {
+    "timerId": "357",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "355"
+   }
+  },
+  {
+   "eventId": "358",
+   "eventTime": "2023-05-19T20:44:06.969865463Z",
+   "eventType": "TimerFired",
+   "taskId": "4198880",
+   "timerFiredEventAttributes": {
+    "timerId": "357",
+    "startedEventId": "357"
+   }
+  },
+  {
+   "eventId": "359",
+   "eventTime": "2023-05-19T20:44:06.969894713Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198881",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "360",
+   "eventTime": "2023-05-19T20:44:06.995487588Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198885",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "359",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "b6b2bd9b-e4fa-401d-a43f-8e2049f89a0d",
+    "historySizeBytes": "76707"
+   }
+  },
+  {
+   "eventId": "361",
+   "eventTime": "2023-05-19T20:44:07.010196879Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198889",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "359",
+    "startedEventId": "360",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "362",
+   "eventTime": "2023-05-19T20:44:07.010223546Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198890",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjUzIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "361"
+   }
+  },
+  {
+   "eventId": "363",
+   "eventTime": "2023-05-19T20:44:07.010227796Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198891",
+   "timerStartedEventAttributes": {
+    "timerId": "363",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "361"
+   }
+  },
+  {
+   "eventId": "364",
+   "eventTime": "2023-05-19T20:44:07.980540338Z",
+   "eventType": "TimerFired",
+   "taskId": "4198894",
+   "timerFiredEventAttributes": {
+    "timerId": "363",
+    "startedEventId": "363"
+   }
+  },
+  {
+   "eventId": "365",
+   "eventTime": "2023-05-19T20:44:07.980567088Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198895",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "366",
+   "eventTime": "2023-05-19T20:44:07.991776296Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198899",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "365",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "84c772a2-e411-403e-9866-3bad73450cc9",
+    "historySizeBytes": "77368"
+   }
+  },
+  {
+   "eventId": "367",
+   "eventTime": "2023-05-19T20:44:08.010365630Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198903",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "365",
+    "startedEventId": "366",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "368",
+   "eventTime": "2023-05-19T20:44:08.010392546Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198904",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjU0Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "367"
+   }
+  },
+  {
+   "eventId": "369",
+   "eventTime": "2023-05-19T20:44:08.010396296Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198905",
+   "timerStartedEventAttributes": {
+    "timerId": "369",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "367"
+   }
+  },
+  {
+   "eventId": "370",
+   "eventTime": "2023-05-19T20:44:08.974258380Z",
+   "eventType": "TimerFired",
+   "taskId": "4198908",
+   "timerFiredEventAttributes": {
+    "timerId": "369",
+    "startedEventId": "369"
+   }
+  },
+  {
+   "eventId": "371",
+   "eventTime": "2023-05-19T20:44:08.974286255Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198909",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "372",
+   "eventTime": "2023-05-19T20:44:08.993080547Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198913",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "371",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "dffd1dbc-29bd-40c9-aa18-a07441627306",
+    "historySizeBytes": "78029"
+   }
+  },
+  {
+   "eventId": "373",
+   "eventTime": "2023-05-19T20:44:09.013159005Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198917",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "371",
+    "startedEventId": "372",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "374",
+   "eventTime": "2023-05-19T20:44:09.013181964Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198918",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjU1Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "373"
+   }
+  },
+  {
+   "eventId": "375",
+   "eventTime": "2023-05-19T20:44:09.013186172Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198919",
+   "timerStartedEventAttributes": {
+    "timerId": "375",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "373"
+   }
+  },
+  {
+   "eventId": "376",
+   "eventTime": "2023-05-19T20:44:09.989252422Z",
+   "eventType": "TimerFired",
+   "taskId": "4198922",
+   "timerFiredEventAttributes": {
+    "timerId": "375",
+    "startedEventId": "375"
+   }
+  },
+  {
+   "eventId": "377",
+   "eventTime": "2023-05-19T20:44:09.989285797Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198923",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "378",
+   "eventTime": "2023-05-19T20:44:10.000103631Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198927",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "377",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "633a25cd-272c-4e37-910d-57a23c78efef",
+    "historySizeBytes": "78690"
+   }
+  },
+  {
+   "eventId": "379",
+   "eventTime": "2023-05-19T20:44:10.014627006Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198931",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "377",
+    "startedEventId": "378",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "380",
+   "eventTime": "2023-05-19T20:44:10.014649881Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198932",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjU2Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "379"
+   }
+  },
+  {
+   "eventId": "381",
+   "eventTime": "2023-05-19T20:44:10.014655256Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198933",
+   "timerStartedEventAttributes": {
+    "timerId": "381",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "379"
+   }
+  },
+  {
+   "eventId": "382",
+   "eventTime": "2023-05-19T20:44:10.978229048Z",
+   "eventType": "TimerFired",
+   "taskId": "4198936",
+   "timerFiredEventAttributes": {
+    "timerId": "381",
+    "startedEventId": "381"
+   }
+  },
+  {
+   "eventId": "383",
+   "eventTime": "2023-05-19T20:44:10.978258089Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198937",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "384",
+   "eventTime": "2023-05-19T20:44:11.001056256Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198941",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "383",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "a3b40584-eeba-4581-b516-eb4c6498fd76",
+    "historySizeBytes": "79349"
+   }
+  },
+  {
+   "eventId": "385",
+   "eventTime": "2023-05-19T20:44:11.016513173Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198945",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "383",
+    "startedEventId": "384",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "386",
+   "eventTime": "2023-05-19T20:44:11.016533964Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198946",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjU3Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "385"
+   }
+  },
+  {
+   "eventId": "387",
+   "eventTime": "2023-05-19T20:44:11.016537881Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198947",
+   "timerStartedEventAttributes": {
+    "timerId": "387",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "385"
+   }
+  },
+  {
+   "eventId": "388",
+   "eventTime": "2023-05-19T20:44:11.980062007Z",
+   "eventType": "TimerFired",
+   "taskId": "4198950",
+   "timerFiredEventAttributes": {
+    "timerId": "387",
+    "startedEventId": "387"
+   }
+  },
+  {
+   "eventId": "389",
+   "eventTime": "2023-05-19T20:44:11.980089423Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198951",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "390",
+   "eventTime": "2023-05-19T20:44:12.002035465Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198955",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "389",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "90e52f88-9591-496e-85fd-aa402936ce8c",
+    "historySizeBytes": "80008"
+   }
+  },
+  {
+   "eventId": "391",
+   "eventTime": "2023-05-19T20:44:12.020554090Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198959",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "389",
+    "startedEventId": "390",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "392",
+   "eventTime": "2023-05-19T20:44:12.020575965Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198960",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjU4Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "391"
+   }
+  },
+  {
+   "eventId": "393",
+   "eventTime": "2023-05-19T20:44:12.020579340Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198961",
+   "timerStartedEventAttributes": {
+    "timerId": "393",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "391"
+   }
+  },
+  {
+   "eventId": "394",
+   "eventTime": "2023-05-19T20:44:12.982406215Z",
+   "eventType": "TimerFired",
+   "taskId": "4198964",
+   "timerFiredEventAttributes": {
+    "timerId": "393",
+    "startedEventId": "393"
+   }
+  },
+  {
+   "eventId": "395",
+   "eventTime": "2023-05-19T20:44:12.982435840Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198965",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "396",
+   "eventTime": "2023-05-19T20:44:13.000578299Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198969",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "395",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "fde58aa7-4dfb-4cd6-bb42-d286ab239dc7",
+    "historySizeBytes": "80667"
+   }
+  },
+  {
+   "eventId": "397",
+   "eventTime": "2023-05-19T20:44:13.019041215Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198973",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "395",
+    "startedEventId": "396",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "398",
+   "eventTime": "2023-05-19T20:44:13.019064132Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198974",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjU5Ig=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "397"
+   }
+  },
+  {
+   "eventId": "399",
+   "eventTime": "2023-05-19T20:44:13.019068965Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198975",
+   "timerStartedEventAttributes": {
+    "timerId": "399",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "397"
+   }
+  },
+  {
+   "eventId": "400",
+   "eventTime": "2023-05-19T20:44:13.983046966Z",
+   "eventType": "TimerFired",
+   "taskId": "4198978",
+   "timerFiredEventAttributes": {
+    "timerId": "399",
+    "startedEventId": "399"
+   }
+  },
+  {
+   "eventId": "401",
+   "eventTime": "2023-05-19T20:44:13.983075591Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198979",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "402",
+   "eventTime": "2023-05-19T20:44:14.002033591Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198983",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "401",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "ea4002ac-852f-4d27-a3f6-74cbc8921ceb",
+    "historySizeBytes": "81326"
+   }
+  },
+  {
+   "eventId": "403",
+   "eventTime": "2023-05-19T20:44:14.017568424Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4198987",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "401",
+    "startedEventId": "402",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "404",
+   "eventTime": "2023-05-19T20:44:14.017595091Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4198988",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYwIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "403"
+   }
+  },
+  {
+   "eventId": "405",
+   "eventTime": "2023-05-19T20:44:14.017599091Z",
+   "eventType": "TimerStarted",
+   "taskId": "4198989",
+   "timerStartedEventAttributes": {
+    "timerId": "405",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "403"
+   }
+  },
+  {
+   "eventId": "406",
+   "eventTime": "2023-05-19T20:44:14.986585466Z",
+   "eventType": "TimerFired",
+   "taskId": "4198992",
+   "timerFiredEventAttributes": {
+    "timerId": "405",
+    "startedEventId": "405"
+   }
+  },
+  {
+   "eventId": "407",
+   "eventTime": "2023-05-19T20:44:14.986611175Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4198993",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "408",
+   "eventTime": "2023-05-19T20:44:15.003753841Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4198997",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "407",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "60aae14c-4df2-40a9-afc3-b6aff62aef6e",
+    "historySizeBytes": "81985"
+   }
+  },
+  {
+   "eventId": "409",
+   "eventTime": "2023-05-19T20:44:15.017715550Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4199001",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "407",
+    "startedEventId": "408",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "410",
+   "eventTime": "2023-05-19T20:44:15.017735925Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4199002",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYxIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "409"
+   }
+  },
+  {
+   "eventId": "411",
+   "eventTime": "2023-05-19T20:44:15.017739925Z",
+   "eventType": "TimerStarted",
+   "taskId": "4199003",
+   "timerStartedEventAttributes": {
+    "timerId": "411",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "409"
+   }
+  },
+  {
+   "eventId": "412",
+   "eventTime": "2023-05-19T20:44:15.986033425Z",
+   "eventType": "TimerFired",
+   "taskId": "4199006",
+   "timerFiredEventAttributes": {
+    "timerId": "411",
+    "startedEventId": "411"
+   }
+  },
+  {
+   "eventId": "413",
+   "eventTime": "2023-05-19T20:44:15.986062009Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4199007",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "414",
+   "eventTime": "2023-05-19T20:44:16.004983342Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4199011",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "413",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "11b371d2-6a7b-41e1-af7c-e46436c51720",
+    "historySizeBytes": "82645"
+   }
+  },
+  {
+   "eventId": "415",
+   "eventTime": "2023-05-19T20:44:16.023547009Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4199015",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "413",
+    "startedEventId": "414",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "416",
+   "eventTime": "2023-05-19T20:44:16.023568925Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4199016",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYyIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "415"
+   }
+  },
+  {
+   "eventId": "417",
+   "eventTime": "2023-05-19T20:44:16.023572384Z",
+   "eventType": "TimerStarted",
+   "taskId": "4199017",
+   "timerStartedEventAttributes": {
+    "timerId": "417",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "415"
+   }
+  },
+  {
+   "eventId": "418",
+   "eventTime": "2023-05-19T20:44:16.987240134Z",
+   "eventType": "TimerFired",
+   "taskId": "4199020",
+   "timerFiredEventAttributes": {
+    "timerId": "417",
+    "startedEventId": "417"
+   }
+  },
+  {
+   "eventId": "419",
+   "eventTime": "2023-05-19T20:44:16.987263426Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4199021",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "420",
+   "eventTime": "2023-05-19T20:44:17.004550676Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4199025",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "419",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "eff9d22a-7ef7-449c-8e71-36497c8f7ea5",
+    "historySizeBytes": "83305"
+   }
+  },
+  {
+   "eventId": "421",
+   "eventTime": "2023-05-19T20:44:17.019046426Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4199029",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "419",
+    "startedEventId": "420",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "422",
+   "eventTime": "2023-05-19T20:44:17.019074676Z",
+   "eventType": "MarkerRecorded",
+   "taskId": "4199030",
+   "markerRecordedEventAttributes": {
+    "markerName": "Version",
+    "details": {
+     "change-id": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "InZlcnkgdmVyeSB2ZXJ5IHZlcnkgbG9uZyB3b3JrZmxvdyB2ZXJzaW9uIGlkOjYzIg=="
+       }
+      ]
+     },
+     "version": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "MQ=="
+       }
+      ]
+     },
+     "version-search-attribute-updated": {
+      "payloads": [
+       {
+        "metadata": {
+         "encoding": "anNvbi9wbGFpbg=="
+        },
+        "data": "ZmFsc2U="
+       }
+      ]
+     }
+    },
+    "workflowTaskCompletedEventId": "421"
+   }
+  },
+  {
+   "eventId": "423",
+   "eventTime": "2023-05-19T20:44:17.019080634Z",
+   "eventType": "TimerStarted",
+   "taskId": "4199031",
+   "timerStartedEventAttributes": {
+    "timerId": "423",
+    "startToFireTimeout": "0.001s",
+    "workflowTaskCompletedEventId": "421"
+   }
+  },
+  {
+   "eventId": "424",
+   "eventTime": "2023-05-19T20:44:17.989613926Z",
+   "eventType": "TimerFired",
+   "taskId": "4199034",
+   "timerFiredEventAttributes": {
+    "timerId": "423",
+    "startedEventId": "423"
+   }
+  },
+  {
+   "eventId": "425",
+   "eventTime": "2023-05-19T20:44:17.989643051Z",
+   "eventType": "WorkflowTaskScheduled",
+   "taskId": "4199035",
+   "workflowTaskScheduledEventAttributes": {
+    "taskQueue": {
+     "name": "Quinn-Klassens-MacBook-Pro.local:219a60c8-a512-4481-a805-9188d4c7a9c6",
+     "kind": "Sticky"
+    },
+    "startToCloseTimeout": "10s",
+    "attempt": 1
+   }
+  },
+  {
+   "eventId": "426",
+   "eventTime": "2023-05-19T20:44:18.007108343Z",
+   "eventType": "WorkflowTaskStarted",
+   "taskId": "4199039",
+   "workflowTaskStartedEventAttributes": {
+    "scheduledEventId": "425",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "requestId": "fbb8de14-c3ee-4257-a349-dd80e17ac574",
+    "historySizeBytes": "83965"
+   }
+  },
+  {
+   "eventId": "427",
+   "eventTime": "2023-05-19T20:44:18.024511926Z",
+   "eventType": "WorkflowTaskCompleted",
+   "taskId": "4199043",
+   "workflowTaskCompletedEventAttributes": {
+    "scheduledEventId": "425",
+    "startedEventId": "426",
+    "identity": "33997@Quinn-Klassens-MacBook-Pro.local@",
+    "binaryChecksum": "f9c95cfef045ca06faa584b57df4ed3d",
+    "sdkMetadata": {
+
+    },
+    "meteringMetadata": {
+
+    }
+   }
+  },
+  {
+   "eventId": "428",
+   "eventTime": "2023-05-19T20:44:18.024536968Z",
+   "eventType": "WorkflowExecutionCompleted",
+   "taskId": "4199044",
+   "workflowExecutionCompletedEventAttributes": {
+    "workflowTaskCompletedEventId": "427"
+   }
+  }
+ ]
+}

--- a/test/replaytests/workflows.go
+++ b/test/replaytests/workflows.go
@@ -263,6 +263,17 @@ func VersionLoopWorkflow(ctx workflow.Context, changeID string, iterations int) 
 	return workflow.Sleep(ctx, time.Second)
 }
 
+func VersionLoopWorkflowMultipleTasks(ctx workflow.Context, changeID string, iterations int) error {
+	for i := 0; i < iterations; i++ {
+		workflow.GetVersion(ctx, fmt.Sprintf("%s:%d", changeID, i), workflow.DefaultVersion, 1)
+		err := workflow.Sleep(ctx, time.Millisecond)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func ChildWorkflowWaitOnSignal(ctx workflow.Context) error {
 	workflow.GetSignalChannel(ctx, "unblock").Receive(ctx, nil)
 	return nil


### PR DESCRIPTION
If flags are found for a task via lookahead we want those flags to be written directly into the current flagset and not the new/pending flagset as residence in the latter is not visible to subsequent callers of sdkFlags.tryUse.